### PR TITLE
(chore): Add tracking section to website

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -1030,6 +1030,10 @@ h2 {
     padding-bottom: 3em;
 }
 
+#tracking{
+    padding-top: 4em;
+    border-bottom: 1px solid #eee;
+}
 
 /* Disable text highlighting */
 .button,

--- a/index.html
+++ b/index.html
@@ -159,7 +159,24 @@
                     </div>
                 </div>
             </section>
+            <section id="tracking">
+                <div class="container">
+                    <div class="col-md-8 col-md-offset-2">
+                        <header>
+                            <h2>Sync with time-tracking services</h2>
+                        </header>
+                        <p>gnome-pomodoro-tracking is an extension that allow sync your pomodoro sessions with
+                            popular time-tracking services.</p>
 
+                        <footer>
+                            <address class="button-box">
+                                <a href="https://github.com/gnome-pomodoro/gnome-pomodoro-tracking"
+                                    class="button button-default"><span>View on Github</span></a>
+                            </address>
+                        </footer>
+                    </div>
+                </div>
+            </section>
             <section id="feedback">
                 <div class="container">
                     <div class="col-md-8 col-md-offset-2">


### PR DESCRIPTION

Description:
-----------

This commit adds a new section to the website that displays information about 
synchronizing pomodoro sessions with time-tracking services.

Here is an example of how it is displayed.

![2024-09-24_18-53](https://github.com/user-attachments/assets/9ac77f96-1221-4f27-a2db-ad69bb9481b8)

Related issues: [#13](https://github.com/gnome-pomodoro/gnome-pomodoro-tracking/issues/13)

